### PR TITLE
Server-side authentication hotfix

### DIFF
--- a/model/errors.ts
+++ b/model/errors.ts
@@ -1,5 +1,6 @@
 export enum Errors {
   INVALID_CREDENTIALS = 'Username and/or password were incorrect.',
+  USER_ALREADY_EXISTS = 'Username and/or email are already in use.',
 }
 
 /**

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -57,6 +57,20 @@ export class AuthenticationService {
     };
 
     await this.DB.ExecuteInsideDatabaseHarness(async (connection) => {
+      // check if there are no other users of same username and/or email
+      const otherUsers: User[] = await connection.query(
+        'SELECT * FROM ' +
+          DatabaseTables.USERS +
+          ' WHERE `username` = ? OR `email` = ?',
+        [newUser.username, newUser.email]
+      );
+
+      if (otherUsers.length !== 0) {
+        // there is at least one — abort
+        throw Err(Errors.USER_ALREADY_EXISTS);
+      }
+
+      // otherwise add to the database
       await connection.query(
         'INSERT INTO ' + DatabaseTables.USERS + ' SET ?',
         newUser


### PR DESCRIPTION
I hate to admit it, but I forgot to add a simple check that prevents from users signing up with an username and/or email that already have been used. This PR fixes this.