### PR TITLE
client, model: moved default from global model to client side

### DIFF
--- a/client/src/app/city-detail/city-detail.component.ts
+++ b/client/src/app/city-detail/city-detail.component.ts
@@ -47,7 +47,7 @@ export class CityDetailComponent implements OnInit {
           this.buildings++;
           // count production
           const name = `building-${c.buildingType}-lvl-${c.buildingLvl}`;
-          const values = BuildingsValues[name];
+          const values = BuildingsValues.default[name];
           this.production.red += c.terrain === 0 ? 2 * values.red : values.red;
           this.production.green +=
             c.terrain === 1 ? 2 * values.green : values.green;

--- a/client/src/app/city/city.component.ts
+++ b/client/src/app/city/city.component.ts
@@ -129,17 +129,17 @@ export class CityComponent implements OnInit {
       }`,
       // curr hourly production
       before:
-        BuildingsValues[
+        BuildingsValues.default[
           `building-${cell.buildingType}-lvl-${cell.buildingLvl}`
         ],
       // hourly production after upgrade
       after:
-        BuildingsValues[
+        BuildingsValues.default[
           `building-${cell.buildingType}-lvl-${cell.buildingLvl + 1}`
         ],
       // cost of upgrade
       cost:
-        BuildingsCosts[
+        BuildingsCosts.default[
           `upgrade-building-${cell.buildingType}-to-lvl-${cell.buildingLvl + 1}`
         ],
     };
@@ -176,18 +176,18 @@ export class CityComponent implements OnInit {
     const data = {
       building1: {
         name: 'Building 1',
-        production: BuildingsValues['building-0-lvl-0'], // possible hourly production
-        cost: BuildingsCosts['buy-building-0'], // cost
+        production: BuildingsValues.default['building-0-lvl-0'], // possible hourly production
+        cost: BuildingsCosts.default['buy-building-0'], // cost
       },
       building2: {
         name: 'Building 2',
-        production: BuildingsValues['building-1-lvl-0'], // possible hourly production
-        cost: BuildingsCosts['buy-building-1'], // cost
+        production: BuildingsValues.default['building-1-lvl-0'], // possible hourly production
+        cost: BuildingsCosts.default['buy-building-1'], // cost
       },
       building3: {
         name: 'Building 3',
-        production: BuildingsValues['building-2-lvl-0'], // possible hourly production
-        cost: BuildingsCosts['buy-building-2'], // cost
+        production: BuildingsValues.default['building-2-lvl-0'], // possible hourly production
+        cost: BuildingsCosts.default['buy-building-2'], // cost
       },
     };
     // show dialog

--- a/model/resource-production/hourly-production.ts
+++ b/model/resource-production/hourly-production.ts
@@ -6,4 +6,4 @@ interface IHourlyProduction {
   [key: string]: Buildings;
 }
 
-export const HourlyProduction: IHourlyProduction = hourlyProduction['default'] as IHourlyProduction;
+export const HourlyProduction: IHourlyProduction = hourlyProduction as IHourlyProduction;

--- a/model/resource-production/upgrade-costs.ts
+++ b/model/resource-production/upgrade-costs.ts
@@ -6,4 +6,4 @@ interface IUpgradeCosts {
   [key: string]: Buildings;
 }
 
-export const UpgradeCosts = upgradeCosts['default'] as IUpgradeCosts;
+export const UpgradeCosts = upgradeCosts as IUpgradeCosts;


### PR DESCRIPTION
Fixing previus error of accesing json data by `default` keyword in model, now moved to client side