### PR TITLE
Added default values to some fields in the `map` table

### DIFF
--- a/server/database/tables.sql
+++ b/server/database/tables.sql
@@ -20,9 +20,9 @@ DROP TABLE IF EXISTS map;
 CREATE TABLE map(
   `id` INT NOT NULL AUTO_INCREMENT,
   `terrain` INT NOT NULL,
-  `owner` INT,
-  `buildingType` INT,
-  `buildingLvl` INT,
+  `owner` INT NOT NULL DEFAULT 0,
+  `buildingType` INT NOT NULL DEFAULT -1,
+  `buildingLvl` INT NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`),
   FOREIGN KEY (`owner`) REFERENCES users(`id`)
   ON DELETE CASCADE

--- a/server/src/services/map.service.ts
+++ b/server/src/services/map.service.ts
@@ -38,7 +38,6 @@ export class MapService {
    * @param index The cell's index number.
    * @param cell The cell object containing information about resources and the like.
    */
-  //TODO: introduce cell's cost.
   public async AssignCellToUser(user: User, index: number): Promise<void> {
     // First ensure that the cell belongs to no one.
     let owner: Cell[];
@@ -46,7 +45,7 @@ export class MapService {
       owner = await connection.query(
         'SELECT * FROM ' +
           DatabaseTables.MAP +
-          ' WHERE `owner` IS NULL AND `id` = ?',
+          ' WHERE `owner` = 0 AND `id` = ?',
         [index]
       );
     });


### PR DESCRIPTION
Let the `map` table be more explicit — default values are set and cannot be `NULL` which gives certainty when checking e.g. if given cell is owned by someone (the `owner` column could have been either `NULL` or `0` whilst meaning the same thing — cell not owned by anyone).
